### PR TITLE
FIX: Correct buffer datatype handling in TCP server node

### DIFF
--- a/tcp-server.js
+++ b/tcp-server.js
@@ -111,7 +111,12 @@ module.exports = function (RED) {
                     if (this.socketTimeout > 0) {
                         socket.setTimeout(this.socketTimeout);// reset timeout
                     }
-                    let parsedData = data.toString(this.datatype);
+                    let parsedData;
+                    if (this.datatype === 'buffer') {
+                        parsedData = data; // Keep as buffer
+                    } else {
+                        parsedData = data.toString(this.datatype);
+                    }
                     this.logger.debug("Got data :" + parsedData);
                     this.send({payload: parsedData, topic: clientId});
                 });


### PR DESCRIPTION
Hello,

First of all, I would like to thank you for your work. I really like your node.

Unfortunately, I have now encountered a problem with the buffer datatype in the TCP server node. When I set the datatype to "buffer", the node doesn't return any data.

I found the issue in the code and would like to contribute a fix. The problem is in the tcp-server.js file where all incoming data is being converted to string using `data.toString(this.datatype)`, even when the datatype is set to 'buffer', causing buffer datatype to not work properly.

I hope this helps improve your excellent node!