### PR TITLE
Stringify data to write only if data type is not a buffer

### DIFF
--- a/tcp-client.js
+++ b/tcp-client.js
@@ -204,7 +204,7 @@ module.exports = function (RED) {
         write(data, done) {
             this.done = done;
             if (this.connection && this.connection.socket) {
-                if (typeof data === "object") {
+                if (this.datatype !== 'buffer' && typeof data === "object") {
                     data = JSON.stringify(data) + "\r\n";
                     this.logger.debug("Object converted to string: " + data);
                 }


### PR DESCRIPTION
When the data type is set to "buffer" and I'm sending a Buffer to the tcp-client node, it gets wrongly converted into a string because the typeof of that is "object".

I have fixed this case by making sure not to convert data into a string if `this.datatype` is "buffer".